### PR TITLE
Adjusted Engine Trip Event to only use target datetime

### DIFF
--- a/app/controllers/abstract_batch_controller.rb
+++ b/app/controllers/abstract_batch_controller.rb
@@ -58,10 +58,8 @@ class AbstractBatchController < ApplicationController
       end
     end
 
-    if intended_status == 'APPROVED'
-      service = Kribi::Exporter::Performer.new(:all)
-      service.perform
-    end
+    service = Kribi::Exporter::Performer.new(:all)
+    service.perform
 
     flash[:success] = "Sucessfully updated status to #{intended_status.downcase} on all records."
     flash.keep

--- a/app/models/abstract_model.rb
+++ b/app/models/abstract_model.rb
@@ -34,7 +34,6 @@ class AbstractModel < ActiveRecord::Base
   end
 
   def previous_records
-    @previous_records ||=
     if persisted?
       parent_children_records.where("id < (?)", self.id).order(:id)
       # .limit((1440 / self.class::INTERVAL_IN_MINUTES) * 2) # last 2 days
@@ -44,7 +43,7 @@ class AbstractModel < ActiveRecord::Base
   end
 
   def previous_record
-    @previous_record ||= previous_records.last
+    previous_records.last
   end
 
   def remove_seconds_from_datetime_column

--- a/app/models/engine_trip_export_event.rb
+++ b/app/models/engine_trip_export_event.rb
@@ -166,7 +166,6 @@ class EngineTripExportEvent < AbstractEventModel
     end
   end
 
-  validates :target_ending_datetime, presence: true
   validates :equipment, presence: true
   validates :bank, presence: true
   validates :cylinder, {
@@ -198,11 +197,11 @@ class EngineTripExportEvent < AbstractEventModel
 
   private
 
-  def calculated_duration_in_hours
-    return unless target_datetime
-    return unless target_ending_datetime
-    (target_ending_datetime.to_datetime - target_datetime.to_datetime).to_f * 24
-  end
+  # NOTE: This calculated field does not apply to current record, only previous
+  # record
+  # def calculated_duration_in_hours
+  #   raise StandardError.new('Do not enable')
+  # end
 
   def calculated_power_generated_during_light_fuel_oil_consumption
     return unless duration_in_hours

--- a/db/migrate/20151130081758_create_engine_trip_events.rb
+++ b/db/migrate/20151130081758_create_engine_trip_events.rb
@@ -14,7 +14,6 @@ class CreateEngineTripEvents < Kribi::Migration
       t.float :mean_load, default: 0.0
       t.text :observations
       t.datetime :target_datetime
-      t.datetime :target_ending_datetime
       t.float :duration_in_hours
       t.integer :status, default: 0
       [

--- a/db/migrate/20160203054358_create_engine_trip_export_events.rb
+++ b/db/migrate/20160203054358_create_engine_trip_export_events.rb
@@ -14,7 +14,6 @@ class CreateEngineTripExportEvents < Kribi::Migration
       t.float :mean_load, default: 0.0
       t.text :observations
       t.datetime :target_datetime
-      t.datetime :target_ending_datetime
       t.float :duration_in_hours
       t.integer :status, default: 0
       [

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -343,7 +343,6 @@ ActiveRecord::Schema.define(version: 20160512034926) do
     t.float    "mean_load",                                         default: 0.0
     t.text     "observations"
     t.datetime "target_datetime"
-    t.datetime "target_ending_datetime"
     t.float    "duration_in_hours"
     t.integer  "status",                                            default: 0
     t.string   "match_key_standard_daily"
@@ -378,7 +377,6 @@ ActiveRecord::Schema.define(version: 20160512034926) do
     t.float    "mean_load",                                         default: 0.0
     t.text     "observations"
     t.datetime "target_datetime"
-    t.datetime "target_ending_datetime"
     t.float    "duration_in_hours"
     t.integer  "status",                                            default: 0
     t.string   "match_key_standard_daily"


### PR DESCRIPTION
- Refactor exporter calls to always run after records update
- Removed target_ending_datetime refs
- Removed instance variable in abstract model that was messing up with callbacks
- Moved calculation logic to previous record on engine trip event
- Replaced exporting logic for engine trip event to mimic engine status change events